### PR TITLE
Updated collection to support client and server

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -161,13 +161,14 @@ local SHOW_DEBUG_RAY_LINES: boolean = true
 -- Allow RaycastModule to write to the output
 local SHOW_OUTPUT_MESSAGES: boolean = true
 
--- The tag name. Used for cleanup.
-local DEFAULT_COLLECTION_TAG_NAME: string = "_RaycastHitboxV4Managed"
-
 --- Initialize required modules
+local RunService: RunService = game:GetService("RunService")
 local CollectionService: CollectionService = game:GetService("CollectionService")
 local HitboxData = require(script.HitboxCaster)
 local Signal = require(script.GoodSignal)
+
+-- The tag name. Used for cleanup.
+local DEFAULT_COLLECTION_TAG_NAME: string = if RunService:IsClient() then "_RaycastHitboxV4ClientManaged" else "_RaycastHitboxV4ServerManaged"
 
 local RaycastHitbox = {}
 RaycastHitbox.__index = RaycastHitbox


### PR DESCRIPTION
Original changes from this [PR](https://github.com/Swordphin/raycastHitboxRbxl/pull/11)

> This PR resolves https://github.com/Swordphin/raycastHitboxRbxl/issues/10 .
> TL;DR : Hitboxes couldn't be created on the same part on both side causing a nil value from the .new constructor on client.
> This PR :
> 
> FIx the problem descibed above
> Remove useless values